### PR TITLE
feat: add Makefile with automation targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,106 @@
+.PHONY: all clean install build package test-local test
+
+# Variables
+BIN_DIR := bin
+EXTENSION_NAME := vscode-winccoa-database
+VERSION := $(shell node -p "require('./package.json').version")
+EXT_PUBLISHER := winccoa-tools-pack
+EXT_NAME := vscode-winccoa-database
+EXT_ID := $(EXT_PUBLISHER).$(EXT_NAME)
+NPM := npm
+VSCE := npx vsce
+
+# Test workspace configuration
+TEST_WORKSPACE ?= .
+CODE_BIN ?= code
+FORCE_CLOSE_VSCODE ?= no
+SKIP_UNINSTALL ?= yes
+CLOSE_OLD_WINDOW ?= no
+
+# Local build counter file
+LOCAL_COUNTER_FILE := $(BIN_DIR)/.local_build_counter
+
+# OS Detection
+ifeq ($(OS),Windows_NT)
+    DETECTED_OS := Windows
+    RM := del /Q /F
+    RMDIR := rmdir /S /Q
+    MKDIR := mkdir
+    KILL_CODE := taskkill /IM Code.exe /F 2>nul || echo "No VS Code process found"
+else
+    DETECTED_OS := $(shell uname -s)
+    RM := rm -f
+    RMDIR := rm -rf
+    MKDIR := mkdir -p
+    KILL_CODE := pkill -f "$(CODE_BIN)" 2>/dev/null || echo "No VS Code process found"
+endif
+
+# Default target
+all: clean install build package
+
+# Clean build artifacts
+clean:
+	@echo "Cleaning build artifacts..."
+	@rm -rf out dist node_modules
+	@rm -rf $(BIN_DIR)
+	@echo "Clean complete."
+
+# Install dependencies
+install:
+	@echo "Installing dependencies..."
+	@$(NPM) install
+	@echo "Dependencies installed."
+
+# Build TypeScript sources
+build:
+	@echo "Building extension..."
+	@$(NPM) run compile
+	@echo "Build complete."
+
+# Run tests
+test:
+	@echo "Running tests..."
+	@$(NPM) test
+	@echo "Tests complete."
+
+# Package extension into .vsix file (production release)
+package:
+	@echo "Packaging production release..."
+	@-$(MKDIR) $(BIN_DIR) 2>/dev/null || true
+	@echo "Updating version badge in README.md..."
+	@node -e "const fs=require('fs'); let c=fs.readFileSync('README.md','utf8'); c=c.replace(/!\[Version\]\(https:\/\/img\.shields\.io\/badge\/version-[^)]*\)/,'![Version](https://img.shields.io/badge/version-$(VERSION)-blue.svg)'); fs.writeFileSync('README.md',c);"
+	@$(VSCE) package --out $(BIN_DIR)/$(EXTENSION_NAME)-$(VERSION).vsix
+	@echo "Extension packaged to $(BIN_DIR)/$(EXTENSION_NAME)-$(VERSION).vsix"
+
+# Quick build without cleaning
+quick: build package
+
+# Development watch mode
+watch:
+	@$(NPM) run watch
+
+# Rebuild (clean + install + build)
+rebuild: clean install build
+
+# Local test target - Build, package with local stamp, replace extension, restart VS Code
+test-local:
+	@node scripts/test-local.js $(BIN_DIR) $(EXTENSION_NAME) $(VERSION) $(EXT_ID) $(CODE_BIN) $(TEST_WORKSPACE)
+
+# Help target
+help:
+	@echo "Available targets:"
+	@echo "  all          - Clean, install, build and package (default)"
+	@echo "  clean        - Remove build artifacts and node_modules"
+	@echo "  install      - Install npm dependencies"
+	@echo "  build        - Compile TypeScript sources"
+	@echo "  test         - Run tests"
+	@echo "  package      - Create .vsix package in bin/ directory (with version badge update)"
+	@echo "  quick        - Build and package without cleaning"
+	@echo "  watch        - Watch and recompile extension on changes"
+	@echo "  rebuild      - Clean, install and build"
+	@echo "  test-local   - Not yet implemented (use build + package instead)"
+	@echo "  help         - Show this help message"
+	@echo ""
+	@echo "Configuration:"
+	@echo "  TEST_WORKSPACE        - Path to test workspace (default: .)"
+	@echo "  CODE_BIN              - VS Code binary (default: code, use 'code-insiders' for Insiders)"

--- a/scripts/test-local.js
+++ b/scripts/test-local.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const [binDir, extensionName, version, extId, codeBin, testWorkspace] = process.argv.slice(2);
+const counterFile = path.join(binDir, '.local_build_counter');
+
+console.log('========================================');
+console.log('Starting Local Test Setup...');
+console.log('========================================\n');
+
+// [1/5] Create counter
+console.log('[1/5] Creating local build counter...');
+if (!fs.existsSync(binDir)) {
+  fs.mkdirSync(binDir, { recursive: true });
+}
+
+let count = 0;
+if (fs.existsSync(counterFile)) {
+  count = parseInt(fs.readFileSync(counterFile, 'utf8').trim(), 10) || 0;
+}
+count++;
+fs.writeFileSync(counterFile, count.toString(), 'utf8');
+
+const localVsix = path.join(binDir, `${extensionName}-${version}-local-${count}.vsix`);
+
+// [2/5] Package
+console.log(`[2/5] Packaging to ${localVsix}...`);
+console.log('Updating version badge in README.md...');
+let readme = fs.readFileSync('README.md', 'utf8');
+readme = readme.replace(/!\[Version\]\(https:\/\/img\.shields\.io\/badge\/version-[^)]*\)/, 
+  `![Version](https://img.shields.io/badge/version-${version}.local.${count}-blue.svg)`);
+fs.writeFileSync('README.md', readme);
+
+console.log('Backing up package.json...');
+const pkgBackup = fs.readFileSync('package.json', 'utf8');
+const pkg = JSON.parse(pkgBackup);
+const originalDisplayName = pkg.displayName;
+
+console.log('Modifying displayName for local build...');
+pkg.displayName = `${originalDisplayName} [LOCAL-${count}]`;
+fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+
+try {
+  execSync(`npx vsce package -o "${localVsix}"`, { stdio: 'inherit' });
+} catch (error) {
+  console.error('Packaging failed!');
+  fs.writeFileSync('package.json', pkgBackup);
+  readme = readme.replace(/!\[Version\]\(https:\/\/img\.shields\.io\/badge\/version-[^)]*\)/, 
+    `![Version](https://img.shields.io/badge/version-${version}-blue.svg)`);
+  fs.writeFileSync('README.md', readme);
+  process.exit(1);
+}
+
+console.log('Restoring package.json...');
+fs.writeFileSync('package.json', pkgBackup);
+
+console.log('Restoring README.md...');
+readme = readme.replace(/!\[Version\]\(https:\/\/img\.shields\.io\/badge\/version-[^)]*\)/, 
+  `![Version](https://img.shields.io/badge/version-${version}-blue.svg)`);
+fs.writeFileSync('README.md', readme);
+
+// [3/5] Uninstall
+console.log('\n[3/5] Uninstalling existing extension...');
+try {
+  execSync(`${codeBin} --uninstall-extension ${extId}`, { stdio: 'pipe' });
+} catch {
+  console.log('Extension not installed or already removed');
+}
+
+// [4/5] Install
+console.log('\n[4/5] Installing new extension...');
+execSync(`${codeBin} --install-extension "${localVsix}" --force`, { stdio: 'inherit' });
+
+// [5/5] Open
+console.log('\n[5/5] Opening VS Code...');
+execSync(`${codeBin} "${testWorkspace}"`, { stdio: 'inherit', detached: true });
+
+console.log('\n✅ Test setup complete!');


### PR DESCRIPTION
Added comprehensive Makefile matching ctrl lang extension with targets:
- make install: Install dependencies
- make build: Compile TypeScript sources
- make test: Run test suite
- make package: Create VSIX with version badge auto-update
- make test-local: Build, package with local counter, install & open in VS Code
- make clean/rebuild/watch/quick/help: Additional utility targets

Also added scripts/test-local.js for automated local testing workflow