### PR TITLE
feat(icon): replace activity bar icon with new WinCC OA database icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
                 {
                     "id": "winccoa-database",
                     "title": "WinCC OA Database",
-                    "icon": "resources/icons/database.svg"
+                    "icon": "resources/icons/winccoa-database.svg"
                 }
             ]
         },

--- a/resources/icons/database.svg
+++ b/resources/icons/database.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <rect x="3" y="3" width="7" height="7" rx="1"/>
-  <rect x="14" y="3" width="7" height="7" rx="1"/>
-  <rect x="3" y="14" width="7" height="7" rx="1"/>
-  <line x1="17.5" y1="14" x2="17.5" y2="21"/>
-  <line x1="14" y1="17.5" x2="21" y2="17.5"/>
-</svg>

--- a/resources/icons/winccoa-database.svg
+++ b/resources/icons/winccoa-database.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <mask id="cylinderMask">
+      <rect x="0" y="0" width="100" height="100" fill="white"/>
+      <rect x="30" y="52" width="66" height="44" rx="7" fill="black"/>
+    </mask>
+  </defs>
+
+  <!-- Database cylinder (maskiert) -->
+  <g mask="url(#cylinderMask)">
+    <ellipse cx="50" cy="18" rx="38" ry="11"
+      stroke="#fff" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <line x1="12" y1="18" x2="12" y2="82"
+      stroke="#fff" stroke-width="6" stroke-linecap="round"/>
+    <line x1="88" y1="18" x2="88" y2="82"
+      stroke="#fff" stroke-width="6" stroke-linecap="round"/>
+    <path d="M 12,39.3 A 38,11 0 0 0 88,39.3"
+      stroke="#fff" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <path d="M 12,60.7 A 38,11 0 0 0 88,60.7"
+      stroke="#fff" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <path d="M 12,82 A 38,11 0 0 0 88,82"
+      stroke="#fff" stroke-width="6" fill="none" stroke-linecap="round"/>
+  </g>
+
+  <!-- OA Badge -->
+  <rect x="30" y="52" width="66" height="44" rx="7"
+    fill="transparent" stroke="#fff" stroke-width="6"/>
+  <text x="63" y="74"
+    text-anchor="middle" dominant-baseline="central"
+    font-family="'Segoe UI', Arial, sans-serif"
+    font-weight="700" font-size="36" fill="#fff">OA</text>
+</svg>


### PR DESCRIPTION
## Summary

Replaces the generic grid-based activity bar icon with a new WinCC OA-specific database icon.

## Changes

- Added `resources/icons/winccoa-database.svg` — new icon showing a database cylinder with an "OA" badge
- Removed `resources/icons/database.svg` (old placeholder icon)
- Updated `package.json` view contribution to reference the new icon path

## Visual

| Before | After |
|--------|-------|
| Generic 4-square grid icon | Database cylinder with OA badge |

## Testing

Tested via `make test-local` — icon renders correctly in the VS Code activity bar after window reload.

<img width="86" height="161" alt="image" src="https://github.com/user-attachments/assets/868c9dbb-5238-4cbf-9ebd-9fdb4494e155" />

