### PR TITLE
feat(drag drop dp name clipboard): #61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,18 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1] - 2026-03-30
 
-### Changed
+### Added
 
-- **BREAKING**: Migrated from better-sqlite3 (native C++ module) to sql.js (WebAssembly)
-    - Extension now works cross-platform (Windows, Linux, macOS) without rebuilding native modules
-    - Single VSIX package works on all operating systems
-    - Simplified installation - no platform-specific builds required
-    - Removed `npm run rebuild` requirement from development workflow
+- Multi-platform VSIX build support (linux-x64 and win32-x64)
+- Marketplace icon for better visibility in VS Code extensions marketplace
 
-### Removed
+### Fixed
 
-- Removed platform-specific native module dependencies (better-sqlite3, electron-rebuild)
-- Removed rebuild instructions from README documentation
+- Security vulnerabilities in npm dependencies
+- CI workflow improvements and branch protection rules
 
 ## [0.1.0] - 2026-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.2.0] - 2026-04-01
+
+### Added
+
+- Drag & drop support for datapoint and element nodes from tree view (#61)
+    - Drag DP/element nodes to VS Code editor to insert full DP name at cursor position
+    - Drag to external applications (browser, chat, terminal) via system clipboard
+    - Full element path is automatically constructed (e.g., `System1:ExampleDP.Value`)
+- "Copy DP Name" context menu command for DP and element nodes
+    - Right-click on any DP or element to copy its full name to clipboard
+    - Confirmation message shown after successful copy
+
 ## [0.1.1] - 2026-03-30
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,8 @@ test: test-unit
 test-unit:
 	@$(NPM) run test:unit
 
-test-local:
+test-local: prebuild-electron
+	@echo "Testing with rebuilt native modules..."
 	@node scripts/test-local.js $(BIN_DIR) $(EXTENSION_NAME) $(VERSION) \
 		$(EXT_ID) $(CODE_BIN) $(TEST_WORKSPACE)
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,21 @@ Automatically connects to WinCC OA projects via:
 2. `winccoa-project-admin` extension API
 3. Workspace folder detection
 
+### Drag & Drop DP Names
+
+Effortlessly copy datapoint names for use in scripts, documentation, or AI assistants:
+
+- **Drag & drop** datapoint or element nodes from the tree view into any VS Code editor or external application
+- **Context menu**: Right-click on DP or element nodes and select "Copy DP Name"
+- Automatically constructs the full element path (e.g., `System1:ExampleDP.config.address`)
+- Works seamlessly with Copilot Chat, terminals, and external tools
+
 ## Architecture
 
 ```text
 VS Code Extension
   |
-  |-- sql.js (read-only) -------> ident.sqlite    (DPTs, elements, DPs)
+  |-- better-sqlite3 (read) ----> ident.sqlite    (DPTs, elements, DPs)
   |                                config.sqlite   (address, alert, archive, ...)
   |                                last_value.sqlite (current values)
   |
@@ -50,7 +59,7 @@ VS Code Extension
                                   (localhost:3001)
 ```
 
-- **Reading**: All data is read from SQLite databases at `{projectDir}/db/wincc_oa/sqlite/` using sql.js (WebAssembly-based SQLite, cross-platform)
+- **Reading**: All data is read from SQLite databases at `{projectDir}/db/wincc_oa/sqlite/` using better-sqlite3 (native Node.js module, prebuilt for Electron and Node.js runtimes)
 - **Writing**: Values are set through the WinCC OA MCP HTTP server, which routes them through the event manager
 
 > **Note**: Direct SQLite writes do not propagate to the WinCC OA runtime. Use the MCP server for value changes.
@@ -78,7 +87,7 @@ VS Code Extension
 code --install-extension vscode-winccoa-database-X.Y.Z.vsix
 ```
 
-The extension works cross-platform on Windows, Linux, and macOS without requiring additional setup.
+The extension works cross-platform on Windows, Linux, and macOS. Native modules are prebuilt for Electron (local VS Code) and Node.js (Remote SSH/Containers).
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-winccoa-database",
     "displayName": "WinCC OA Database Explorer",
     "description": "Browse and edit WinCC OA datapoint types and datapoints directly from VS Code",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "publisher": "winccoa-tools-pack",
     "author": "winccoa-tools-pack",
     "license": "MIT",
@@ -73,6 +73,12 @@
                 "category": "WinCC OA Database"
             },
             {
+                "command": "winccoa-database.copyDpName",
+                "title": "Copy DP Name",
+                "icon": "$(copy)",
+                "category": "WinCC OA Database"
+            },
+            {
                 "command": "winccoa-database.createDp",
                 "title": "New Datapoint",
                 "icon": "$(add)",
@@ -136,6 +142,16 @@
                     "command": "winccoa-database.deleteDpType",
                     "when": "view == winccoa-database.dptView && viewItem == dpt",
                     "group": "2_delete"
+                },
+                {
+                    "command": "winccoa-database.copyDpName",
+                    "when": "view == winccoa-database.dptView && viewItem == dp",
+                    "group": "9_cutcopypaste@1"
+                },
+                {
+                    "command": "winccoa-database.copyDpName",
+                    "when": "view == winccoa-database.dptView && viewItem == dpElement",
+                    "group": "9_cutcopypaste@1"
                 }
             ],
             "commandPalette": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,6 +90,7 @@ export async function activate(context: vscode.ExtensionContext) {
         treeDataProvider: dptTreeProvider,
         showCollapseAll: true,
         canSelectMany: true,
+        dragAndDropController: dptTreeProvider,
     });
     context.subscriptions.push(dptTreeView);
     log.info('Tree views registered');
@@ -127,6 +128,22 @@ export async function activate(context: vscode.ExtensionContext) {
             );
             if (item && item.dpId !== undefined && item.elId !== undefined) {
                 openConfigEditor(item.dpId, item.elId, item.label, context.extensionUri);
+            }
+        }),
+        vscode.commands.registerCommand('winccoa-database.copyDpName', async (item) => {
+            log.info(
+                `Command: copyDpName, item=${JSON.stringify(item?.label)}, itemType=${item?.itemType}`,
+            );
+            if (item && item.getFullDpName) {
+                const fullName = item.getFullDpName();
+                if (fullName) {
+                    await vscode.env.clipboard.writeText(fullName);
+                    vscode.window.showInformationMessage(`Copied: ${fullName}`);
+                    log.info(`Copied DP name to clipboard: ${fullName}`);
+                } else {
+                    vscode.window.showWarningMessage('Could not determine DP name');
+                    log.warn('copyDpName: getFullDpName() returned undefined');
+                }
             }
         }),
         vscode.commands.registerCommand('winccoa-database.createDp', async (item) => {

--- a/src/providers/dptTreeProvider.ts
+++ b/src/providers/dptTreeProvider.ts
@@ -16,6 +16,7 @@ export class DatabaseTreeItem extends vscode.TreeItem {
         public readonly dpId: number = 0,
         public readonly elId: number = 0,
         public readonly datatype: number = 0,
+        public readonly db?: SqliteClient,
     ) {
         super(label, collapsibleState);
 
@@ -48,9 +49,38 @@ export class DatabaseTreeItem extends vscode.TreeItem {
                 break;
         }
     }
+
+    /**
+     * Get the full DP name for this tree item.
+     * - For DPT: returns the DPT name
+     * - For DP: returns the DP name (e.g., "System1:ExampleDP")
+     * - For dpElement: returns the full element path (e.g., "System1:ExampleDP.Value")
+     */
+    getFullDpName(): string | undefined {
+        if (!this.db) return undefined;
+
+        switch (this.itemType) {
+            case 'dpt':
+                return this.label;
+            case 'dp':
+                return this.label;
+            case 'dpElement': {
+                const dpName = this.db.getDatapointName(this.dpId);
+                if (!dpName) return undefined;
+                const elementPath = this.db.getElementPath(this.dpId, this.elId);
+                return elementPath ? `${dpName}.${elementPath}` : dpName;
+            }
+            default:
+                return undefined;
+        }
+    }
 }
 
-export class DptTreeProvider implements vscode.TreeDataProvider<DatabaseTreeItem> {
+export class DptTreeProvider
+    implements vscode.TreeDataProvider<DatabaseTreeItem>, vscode.TreeDragAndDropController<DatabaseTreeItem>
+{
+    dropMimeTypes = [];
+    dragMimeTypes = ['text/plain'];
     private _onDidChangeTreeData = new vscode.EventEmitter<DatabaseTreeItem | undefined | null>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
@@ -96,6 +126,27 @@ export class DptTreeProvider implements vscode.TreeDataProvider<DatabaseTreeItem
         }
     }
 
+    /**
+     * Handle drag operation - provide the full DP name as text/plain
+     */
+    handleDrag(source: DatabaseTreeItem[], dataTransfer: vscode.DataTransfer): void {
+        if (source.length === 0) return;
+
+        const item = source[0];
+        const fullName = item.getFullDpName();
+        if (fullName) {
+            dataTransfer.set('text/plain', new vscode.DataTransferItem(fullName));
+            log.info(`[Drag] Set text/plain = "${fullName}"`);
+        }
+    }
+
+    /**
+     * Handle drop operation - not needed for our use case, but required by interface
+     */
+    handleDrop(): void {
+        // Not implemented - we only support dragging out, not dropping in
+    }
+
     /** Root level: all DPTs */
     private getRootChildren(): DatabaseTreeItem[] {
         const dpTypes = this.db.getAllDpTypes();
@@ -112,6 +163,10 @@ export class DptTreeProvider implements vscode.TreeDataProvider<DatabaseTreeItem
                     vscode.TreeItemCollapsibleState.Collapsed,
                     'dpt',
                     dpt.dpt_id,
+                    0,
+                    0,
+                    0,
+                    this.db,
                 ),
         );
     }
@@ -132,6 +187,9 @@ export class DptTreeProvider implements vscode.TreeDataProvider<DatabaseTreeItem
                 'dp',
                 dp.dpt_id,
                 dp.dp_id,
+                0,
+                0,
+                this.db,
             );
         });
     }
@@ -188,6 +246,7 @@ export class DptTreeProvider implements vscode.TreeDataProvider<DatabaseTreeItem
                 dpId,
                 el.el_id,
                 el.datatype,
+                this.db,
             );
         });
     }

--- a/src/providers/dptTreeProvider.ts
+++ b/src/providers/dptTreeProvider.ts
@@ -77,7 +77,9 @@ export class DatabaseTreeItem extends vscode.TreeItem {
 }
 
 export class DptTreeProvider
-    implements vscode.TreeDataProvider<DatabaseTreeItem>, vscode.TreeDragAndDropController<DatabaseTreeItem>
+    implements
+        vscode.TreeDataProvider<DatabaseTreeItem>,
+        vscode.TreeDragAndDropController<DatabaseTreeItem>
 {
     dropMimeTypes = [];
     dragMimeTypes = ['text/plain'];

--- a/src/providers/dptTreeProvider.ts
+++ b/src/providers/dptTreeProvider.ts
@@ -57,14 +57,13 @@ export class DatabaseTreeItem extends vscode.TreeItem {
      * - For dpElement: returns the full element path (e.g., "System1:ExampleDP.Value")
      */
     getFullDpName(): string | undefined {
-        if (!this.db) return undefined;
-
         switch (this.itemType) {
             case 'dpt':
                 return this.label;
             case 'dp':
                 return this.label;
             case 'dpElement': {
+                if (!this.db) return undefined;
                 const dpName = this.db.getDatapointName(this.dpId);
                 if (!dpName) return undefined;
                 const elementPath = this.db.getElementPath(this.dpId, this.elId);

--- a/src/test/unit/dptTreeProvider.test.ts
+++ b/src/test/unit/dptTreeProvider.test.ts
@@ -1,0 +1,288 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { DatabaseTreeItem, DptTreeProvider } from '../../providers/dptTreeProvider';
+import { SqliteClient } from '../../db/sqliteClient';
+
+suite('DptTreeProvider Unit Tests', () => {
+    suite('DatabaseTreeItem.getFullDpName()', () => {
+        test('should return DPT name for DPT item', () => {
+            const item = new DatabaseTreeItem(
+                'ExampleDPT',
+                vscode.TreeItemCollapsibleState.Collapsed,
+                'dpt',
+                1,
+                0,
+                0,
+                0,
+                undefined,
+            );
+
+            const result = item.getFullDpName();
+            assert.strictEqual(result, 'ExampleDPT');
+        });
+
+        test('should return DP name for DP item', () => {
+            const item = new DatabaseTreeItem(
+                'System1:ExampleDP',
+                vscode.TreeItemCollapsibleState.Collapsed,
+                'dp',
+                1,
+                100,
+                0,
+                0,
+                undefined,
+            );
+
+            const result = item.getFullDpName();
+            assert.strictEqual(result, 'System1:ExampleDP');
+        });
+
+        test('should return undefined for dpElement without db', () => {
+            const item = new DatabaseTreeItem(
+                'Value',
+                vscode.TreeItemCollapsibleState.None,
+                'dpElement',
+                1,
+                100,
+                5,
+                23, // Int type
+                undefined, // no db
+            );
+
+            const result = item.getFullDpName();
+            assert.strictEqual(result, undefined);
+        });
+
+        test('should construct full path for dpElement with mock db', () => {
+            // Create a mock SqliteClient
+            const mockDb = {
+                getDatapointName: (dpId: number) => {
+                    if (dpId === 100) return 'System1:ExampleDP';
+                    return undefined;
+                },
+                getElementPath: (dpId: number, elId: number) => {
+                    if (dpId === 100 && elId === 5) return 'config.address';
+                    return undefined;
+                },
+            } as unknown as SqliteClient;
+
+            const item = new DatabaseTreeItem(
+                'address',
+                vscode.TreeItemCollapsibleState.None,
+                'dpElement',
+                1,
+                100,
+                5,
+                25, // String type
+                mockDb,
+            );
+
+            const result = item.getFullDpName();
+            assert.strictEqual(result, 'System1:ExampleDP.config.address');
+        });
+
+        test('should handle missing element path gracefully', () => {
+            const mockDb = {
+                getDatapointName: (dpId: number) => {
+                    if (dpId === 100) return 'System1:ExampleDP';
+                    return undefined;
+                },
+                getElementPath: () => undefined,
+            } as unknown as SqliteClient;
+
+            const item = new DatabaseTreeItem(
+                'unknownElement',
+                vscode.TreeItemCollapsibleState.None,
+                'dpElement',
+                1,
+                100,
+                999,
+                23,
+                mockDb,
+            );
+
+            const result = item.getFullDpName();
+            assert.strictEqual(result, 'System1:ExampleDP');
+        });
+
+        test('should return undefined if DP name not found', () => {
+            const mockDb = {
+                getDatapointName: () => undefined,
+                getElementPath: () => 'some.path',
+            } as unknown as SqliteClient;
+
+            const item = new DatabaseTreeItem(
+                'element',
+                vscode.TreeItemCollapsibleState.None,
+                'dpElement',
+                1,
+                999,
+                5,
+                23,
+                mockDb,
+            );
+
+            const result = item.getFullDpName();
+            assert.strictEqual(result, undefined);
+        });
+    });
+
+    suite('DptTreeProvider.handleDrag()', () => {
+        let provider: DptTreeProvider;
+        let mockDb: SqliteClient;
+
+        suiteSetup(() => {
+            mockDb = {
+                isOpen: true,
+                getDatapointName: (dpId: number) => {
+                    if (dpId === 100) return 'System1:TestDP';
+                    return undefined;
+                },
+                getElementPath: (dpId: number, elId: number) => {
+                    if (dpId === 100 && elId === 5) return 'Value';
+                    return undefined;
+                },
+            } as unknown as SqliteClient;
+
+            provider = new DptTreeProvider(mockDb);
+        });
+
+        test('should set text/plain in DataTransfer for DP item', () => {
+            const item = new DatabaseTreeItem(
+                'System1:TestDP',
+                vscode.TreeItemCollapsibleState.Collapsed,
+                'dp',
+                1,
+                100,
+                0,
+                0,
+                mockDb,
+            );
+
+            const dataTransfer = new vscode.DataTransfer();
+            provider.handleDrag([item], dataTransfer);
+
+            const textData = dataTransfer.get('text/plain');
+            assert.ok(textData, 'text/plain should be set');
+            assert.strictEqual(textData?.value, 'System1:TestDP');
+        });
+
+        test('should set text/plain in DataTransfer for dpElement item', () => {
+            const item = new DatabaseTreeItem(
+                'Value',
+                vscode.TreeItemCollapsibleState.None,
+                'dpElement',
+                1,
+                100,
+                5,
+                23,
+                mockDb,
+            );
+
+            const dataTransfer = new vscode.DataTransfer();
+            provider.handleDrag([item], dataTransfer);
+
+            const textData = dataTransfer.get('text/plain');
+            assert.ok(textData, 'text/plain should be set');
+            assert.strictEqual(textData?.value, 'System1:TestDP.Value');
+        });
+
+        test('should handle empty source array gracefully', () => {
+            const dataTransfer = new vscode.DataTransfer();
+            provider.handleDrag([], dataTransfer);
+
+            const textData = dataTransfer.get('text/plain');
+            assert.strictEqual(textData, undefined, 'text/plain should not be set for empty array');
+        });
+
+        test('should handle item without full name gracefully', () => {
+            const item = new DatabaseTreeItem(
+                'Unknown',
+                vscode.TreeItemCollapsibleState.None,
+                'dpElement',
+                1,
+                999, // non-existent DP
+                999,
+                23,
+                mockDb,
+            );
+
+            const dataTransfer = new vscode.DataTransfer();
+            provider.handleDrag([item], dataTransfer);
+
+            const textData = dataTransfer.get('text/plain');
+            assert.strictEqual(
+                textData,
+                undefined,
+                'text/plain should not be set if full name cannot be determined',
+            );
+        });
+
+        test('should only process first item in multi-selection', () => {
+            const item1 = new DatabaseTreeItem(
+                'System1:TestDP',
+                vscode.TreeItemCollapsibleState.Collapsed,
+                'dp',
+                1,
+                100,
+                0,
+                0,
+                mockDb,
+            );
+
+            const item2 = new DatabaseTreeItem(
+                'System1:OtherDP',
+                vscode.TreeItemCollapsibleState.Collapsed,
+                'dp',
+                1,
+                200,
+                0,
+                0,
+                mockDb,
+            );
+
+            const dataTransfer = new vscode.DataTransfer();
+            provider.handleDrag([item1, item2], dataTransfer);
+
+            const textData = dataTransfer.get('text/plain');
+            assert.ok(textData, 'text/plain should be set');
+            assert.strictEqual(textData?.value, 'System1:TestDP', 'should use first item only');
+        });
+    });
+
+    suite('DatabaseTreeItem context values', () => {
+        test('should set contextValue "dpt" for DPT items', () => {
+            const item = new DatabaseTreeItem(
+                'TestDPT',
+                vscode.TreeItemCollapsibleState.Collapsed,
+                'dpt',
+                1,
+            );
+            assert.strictEqual(item.contextValue, 'dpt');
+        });
+
+        test('should set contextValue "dp" for DP items', () => {
+            const item = new DatabaseTreeItem(
+                'System1:TestDP',
+                vscode.TreeItemCollapsibleState.Collapsed,
+                'dp',
+                1,
+                100,
+            );
+            assert.strictEqual(item.contextValue, 'dp');
+        });
+
+        test('should set contextValue "dpElement" for element items', () => {
+            const item = new DatabaseTreeItem(
+                'Value',
+                vscode.TreeItemCollapsibleState.None,
+                'dpElement',
+                1,
+                100,
+                5,
+                23,
+            );
+            assert.strictEqual(item.contextValue, 'dpElement');
+        });
+    });
+});


### PR DESCRIPTION
Effortlessly copy datapoint names for use in scripts, documentation, or AI assistants:

Drag & drop datapoint or element nodes from the tree view into any VS Code editor or external application
Context menu: Right-click on DP or element nodes and select "Copy DP Name"
Automatically constructs the full element path (e.g., System1:ExampleDP.config.address)
Works seamlessly with Copilot Chat, terminals, and external tools

https://github.com/winccoa-tools-pack/vscode-winccoa-database/issues/61 