### PR TITLE
feat(devOps): add workflow to auto-rebase open PRs

### DIFF
--- a/.github/workflows/rebase-open-prs.yml
+++ b/.github/workflows/rebase-open-prs.yml
@@ -1,0 +1,12 @@
+name: Rebase open PRs
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  rebase-prs:
+    uses: mPokornyETM/rebase-open-prs-action/.github/workflows/rebase-open-prs.yml@v1
+    secrets:
+      GH_PAT: ${{ secrets.GH_TOKEN_PAT }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically rebases all open PRs when the \develop\ branch receives new commits.

## What it does
- Triggers on push to \develop\ branch
- Uses the reusable action \mPokornyETM/rebase-open-prs-action@v1\
- Requires \GH_TOKEN_PAT\ secret with \epo\ scope

## Requirements
Ensure the \GH_TOKEN_PAT\ organization secret is configured with a PAT that has \epo\ scope.

> Replaces #66 (branch renamed from \eat/\ to \eature/\ to comply with GitFlow CI convention).