### PR TITLE
fix(build): make Makefile cross-platform compatible on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ PLATFORM      := $(shell node -p "process.platform")
 ARCH          := $(shell node -p "process.arch")
 NODE_ABI      := $(shell node -p "process.versions.modules")
 NODE_GYP      := npx node-gyp
+NODE_RM       := node -e "require('fs').rmSync(process.argv[1], { recursive: true, force: true, maxRetries: 10, retryDelay: 200 })"
+NODE_MKDIR    := node -e "require('fs').mkdirSync(process.argv[1], { recursive: true })"
+NODE_LS       := node -e "const fs=require('fs'); const path=require('path'); const dir=process.argv[1]; if (fs.existsSync(dir)) { for (const entry of fs.readdirSync(dir)) console.log(path.join(dir, entry)); }"
 
 # Test workspace configuration
 TEST_WORKSPACE ?= .
@@ -25,12 +28,15 @@ all: clean install build prebuilds package
 # ── Clean ─────────────────────────────────────────────────────────────
 clean:
 	@echo "Cleaning build artifacts..."
-	@rm -rf out dist $(BIN_DIR) $(PREBUILDS_DIR)
+	@$(NODE_RM) out
+	@$(NODE_RM) dist
+	@$(NODE_RM) $(BIN_DIR)
+	@$(NODE_RM) $(PREBUILDS_DIR)
 	@echo "Clean complete."
 
 clean-all: clean
 	@echo "Removing node_modules..."
-	@rm -rf node_modules
+	@$(NODE_RM) node_modules
 	@echo "Clean-all complete."
 
 # ── Install ───────────────────────────────────────────────────────────
@@ -61,33 +67,29 @@ ELECTRON_ARCH ?= $(ARCH)
 
 prebuilds: prebuild-node prebuild-electron
 	@echo "Prebuilds collected in $(PREBUILDS_DIR)/$(PLATFORM)-$(ARCH)/"
-	@ls -1 $(PREBUILDS_DIR)/$(PLATFORM)-$(ARCH)/
+	@$(NODE_LS) $(PREBUILDS_DIR)/$(PLATFORM)-$(ARCH)
 
 prebuild-node:
 	@echo "Downloading portable Node.js prebuilds from GitHub releases..."
 	@node scripts/collect-prebuilds.js --platform $(PLATFORM) --arch $(ARCH) --download-node $(NODE_TARGETS)
 
+# Electron version targeted by VS Code (update when bumping engines.vscode)
+ELECTRON_VERSION ?= 39.3.0
+
 prebuild-electron:
-	@NODE_MAJOR=$$(node -p "process.versions.node.split('.')[0]"); \
-	if [ "$$NODE_MAJOR" -lt 22 ]; then \
-		echo "Skipping Electron prebuild: @electron/rebuild requires Node >= 22 (have $$(node --version))"; \
-	else \
-		echo "Rebuilding for Electron (arch=$(ELECTRON_ARCH))..." && \
-		npx electron-rebuild -v 39.3.0 --arch $(ELECTRON_ARCH) && \
-		echo "Collecting Electron prebuild..." && \
-		node scripts/collect-prebuilds.js --platform $(PLATFORM) --arch $(ELECTRON_ARCH) --electron; \
-	fi
+	@echo "Downloading Electron $(ELECTRON_VERSION) prebuild from GitHub releases..."
+	@node scripts/collect-prebuilds.js --platform $(PLATFORM) --arch $(ELECTRON_ARCH) --download-electron $(ELECTRON_VERSION)
 
 # ── Package ───────────────────────────────────────────────────────────
 package:
 	@echo "Packaging VSIX..."
-	@mkdir -p $(BIN_DIR)
+	@$(NODE_MKDIR) $(BIN_DIR)
 	@$(VSCE) package --out $(BIN_DIR)/$(EXTENSION_NAME)-$(VERSION).vsix
 	@echo "Packaged: $(BIN_DIR)/$(EXTENSION_NAME)-$(VERSION).vsix"
 
 package-target:
 	@echo "Packaging platform-specific VSIX ($(PLATFORM)-$(ARCH))..."
-	@mkdir -p $(BIN_DIR)
+	@$(NODE_MKDIR) $(BIN_DIR)
 	@$(VSCE) package --target $(PLATFORM)-$(ARCH) \
 		--out $(BIN_DIR)/$(EXTENSION_NAME)-$(VERSION)-$(PLATFORM)-$(ARCH).vsix
 	@echo "Packaged: $(BIN_DIR)/$(EXTENSION_NAME)-$(VERSION)-$(PLATFORM)-$(ARCH).vsix"

--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,7 @@ info:
 	@echo "Platform:   $(PLATFORM)-$(ARCH)"
 	@echo "Node ABI:   $(NODE_ABI)"
 	@echo "Prebuilds:  $(PREBUILDS_DIR)/$(PLATFORM)-$(ARCH)/"
-	@test -d "$(PREBUILDS_DIR)/$(PLATFORM)-$(ARCH)" \
-		&& ls -1 $(PREBUILDS_DIR)/$(PLATFORM)-$(ARCH)/ \
-		|| echo "  (none — run 'make prebuilds')"
+	@node -e "const fs=require('fs'),path=require('path');const d='$(PREBUILDS_DIR)/$(PLATFORM)-$(ARCH)';if(fs.existsSync(d)){for(const e of fs.readdirSync(d))console.log(' '+path.join(d,e));}else{console.log('  (none \u2014 run \'make prebuilds\')')}"
 
 # ── Help ──────────────────────────────────────────────────────────────
 help:

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "webpack-cli": "^7.0.2"
             },
             "engines": {
-                "vscode": "^1.110.0"
+                "vscode": "^1.118.0"
             }
         },
         "node_modules/@azu/format-text": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     },
     "homepage": "https://github.com/winccoa-tools-pack/vscode-winccoa-database#readme",
     "engines": {
-        "vscode": "^1.110.0"
+        "vscode": "^1.118.0"
     },
     "main": "./dist/extension.js",
     "activationEvents": [

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "extensionDependencies": [],
     "devDependencies": {
         "@electron/rebuild": "^4.0.4",
+        "prebuild-install": "^7.1.3",
         "@eslint/js": "^9.39.2",
         "@types/better-sqlite3": "^7.6.12",
         "@types/mocha": "^10.0.10",

--- a/scripts/collect-prebuilds.js
+++ b/scripts/collect-prebuilds.js
@@ -182,9 +182,7 @@ if (mode === '--download-electron') {
         const actualAbi = match[1];
         if (actualAbi !== targetAbi) {
             fs.unlinkSync(dest);
-            console.error(
-                `ABI mismatch! Expected ${targetAbi} but binary reports ${actualAbi}.`,
-            );
+            console.error(`ABI mismatch! Expected ${targetAbi} but binary reports ${actualAbi}.`);
             process.exit(1);
         }
         console.log(`ABI verified: ${actualAbi} \u2713`);
@@ -270,8 +268,8 @@ if (mode === '--electron') {
             fs.unlinkSync(dest);
             console.error(
                 `ABI mismatch! Expected ${targetAbi} but binary reports ${actualAbi}.\n` +
-                `The binary in ${SOURCE} was not rebuilt for Electron.\n` +
-                `Run "npm run rebuild" or check that electron-rebuild succeeded.`,
+                    `The binary in ${SOURCE} was not rebuilt for Electron.\n` +
+                    `Run "npm run rebuild" or check that electron-rebuild succeeded.`,
             );
             process.exit(1);
         }
@@ -281,8 +279,8 @@ if (mode === '--electron') {
         // which would mean it was built for Node.js (not Electron) — that's wrong.
         console.error(
             `ABI mismatch! Binary loaded cleanly under Node.js ${process.version}.\n` +
-            `Expected an Electron binary (ABI ${targetAbi}), but got a Node.js binary.\n` +
-            `The binary in ${SOURCE} was not rebuilt for Electron.`,
+                `Expected an Electron binary (ABI ${targetAbi}), but got a Node.js binary.\n` +
+                `The binary in ${SOURCE} was not rebuilt for Electron.`,
         );
         fs.unlinkSync(dest);
         process.exit(1);

--- a/scripts/collect-prebuilds.js
+++ b/scripts/collect-prebuilds.js
@@ -44,9 +44,14 @@ for (let i = 0; i < rawArgs.length; i++) {
 const PREBUILDS_DIR = path.join(ROOT, 'prebuilds', `${targetPlatform}-${targetArch}`);
 
 const mode = args[0];
-if (mode !== '--node' && mode !== '--electron' && mode !== '--download-node') {
+if (
+    mode !== '--node' &&
+    mode !== '--electron' &&
+    mode !== '--download-node' &&
+    mode !== '--download-electron'
+) {
     console.error(
-        'Usage: node scripts/collect-prebuilds.js [--platform <p>] [--arch <a>] --node|--electron|--download-node <versions...>',
+        'Usage: node scripts/collect-prebuilds.js [--platform <p>] [--arch <a>] --node|--electron|--download-node|--download-electron <version>',
     );
     process.exit(1);
 }
@@ -112,6 +117,95 @@ if (mode === '--download-node') {
     process.exit(0);
 }
 
+// ── Download Electron prebuild from GitHub releases ────────────────
+if (mode === '--download-electron') {
+    const electronVersion = args[1];
+    if (!electronVersion) {
+        console.error('Provide Electron target version (e.g. 39.3.0)');
+        process.exit(1);
+    }
+    const electronMajor = parseInt(electronVersion.split('.')[0], 10);
+
+    // Electron major -> ABI mapping
+    const electronAbiMap = {
+        32: '128',
+        33: '130',
+        34: '132',
+        35: '133',
+        36: '135',
+        37: '136',
+        38: '139',
+        39: '140',
+    };
+    const targetAbi = electronAbiMap[electronMajor];
+    if (!targetAbi) {
+        console.error(`Unknown Electron major version: ${electronMajor}`);
+        process.exit(1);
+    }
+
+    console.log(`Downloading prebuild for Electron ${electronVersion} (ABI ${targetAbi})...`);
+    const cwd = path.join(ROOT, 'node_modules', 'better-sqlite3');
+    execFileSync(
+        process.execPath,
+        [
+            require.resolve('prebuild-install/bin'),
+            '--runtime',
+            'electron',
+            '--target',
+            electronVersion,
+            '--arch',
+            targetArch,
+            '--platform',
+            targetPlatform,
+            '--force',
+        ],
+        { cwd, stdio: 'inherit' },
+    );
+
+    if (!fs.existsSync(SOURCE)) {
+        console.error(`prebuild-install did not produce ${SOURCE}`);
+        process.exit(1);
+    }
+
+    const dest = path.join(PREBUILDS_DIR, `better_sqlite3_${targetAbi}.node`);
+    fs.copyFileSync(SOURCE, dest);
+    console.log(`Collected: ${dest}`);
+
+    // Verify ABI
+    const { spawnSync } = require('child_process');
+    const result = spawnSync(process.execPath, ['-e', `require(${JSON.stringify(dest)})`], {
+        encoding: 'utf8',
+    });
+    const output = result.stderr || result.stdout || '';
+    const match = output.match(/NODE_MODULE_VERSION\s+(\d+)/);
+    if (match) {
+        const actualAbi = match[1];
+        if (actualAbi !== targetAbi) {
+            fs.unlinkSync(dest);
+            console.error(
+                `ABI mismatch! Expected ${targetAbi} but binary reports ${actualAbi}.`,
+            );
+            process.exit(1);
+        }
+        console.log(`ABI verified: ${actualAbi} \u2713`);
+    } else if (result.status === 0) {
+        fs.unlinkSync(dest);
+        console.error(
+            `ABI mismatch! Binary loaded under Node.js ${process.version} — expected Electron ABI ${targetAbi}.`,
+        );
+        process.exit(1);
+    }
+
+    // Clean up nested node_modules from prebuild-install
+    const nestedModules = path.join(ROOT, 'node_modules', 'better-sqlite3', 'node_modules');
+    if (fs.existsSync(nestedModules)) {
+        fs.rmSync(nestedModules, { recursive: true, force: true });
+        console.log('Cleaned up nested node_modules from prebuild-install.');
+    }
+
+    process.exit(0);
+}
+
 // ── Collect from local build ───────────────────────────────────────
 if (!fs.existsSync(SOURCE)) {
     console.error(`Source not found: ${SOURCE}`);
@@ -158,3 +252,41 @@ if (mode === '--node') {
 const dest = path.join(PREBUILDS_DIR, `better_sqlite3_${targetAbi}.node`);
 fs.copyFileSync(SOURCE, dest);
 console.log(`Copied: ${dest}`);
+
+// Verify the ABI of the collected binary for Electron builds.
+// A native .node file's NODE_MODULE_VERSION is embedded in the file as a numeric constant.
+// We run a child process that loads the binary under the current Node.js (which has a
+// different ABI than Electron), so we expect an error whose message contains the actual ABI.
+if (mode === '--electron') {
+    const { spawnSync } = require('child_process');
+    const result = spawnSync(process.execPath, ['-e', `require(${JSON.stringify(dest)})`], {
+        encoding: 'utf8',
+    });
+    const output = result.stderr || result.stdout || '';
+    const match = output.match(/NODE_MODULE_VERSION\s+(\d+)/);
+    if (match) {
+        const actualAbi = match[1];
+        if (actualAbi !== String(targetAbi)) {
+            fs.unlinkSync(dest);
+            console.error(
+                `ABI mismatch! Expected ${targetAbi} but binary reports ${actualAbi}.\n` +
+                `The binary in ${SOURCE} was not rebuilt for Electron.\n` +
+                `Run "npm run rebuild" or check that electron-rebuild succeeded.`,
+            );
+            process.exit(1);
+        }
+        console.log(`ABI verified: ${actualAbi} ✓`);
+    } else if (result.status === 0) {
+        // No error means the binary loaded successfully under the current Node.js,
+        // which would mean it was built for Node.js (not Electron) — that's wrong.
+        console.error(
+            `ABI mismatch! Binary loaded cleanly under Node.js ${process.version}.\n` +
+            `Expected an Electron binary (ABI ${targetAbi}), but got a Node.js binary.\n` +
+            `The binary in ${SOURCE} was not rebuilt for Electron.`,
+        );
+        fs.unlinkSync(dest);
+        process.exit(1);
+    }
+    // If result.stderr has no NODE_MODULE_VERSION pattern and status != 0,
+    // something else went wrong — ignore and let the build continue.
+}

--- a/scripts/collect-prebuilds.js
+++ b/scripts/collect-prebuilds.js
@@ -58,6 +58,18 @@ if (
 
 fs.mkdirSync(PREBUILDS_DIR, { recursive: true });
 
+// Electron major -> ABI mapping (update when targeting new Electron versions)
+const ELECTRON_ABI_MAP = {
+    32: '128',
+    33: '130',
+    34: '132',
+    35: '133',
+    36: '135',
+    37: '136',
+    38: '139',
+    39: '140',
+};
+
 // ── Download prebuilds from GitHub releases ────────────────────────
 if (mode === '--download-node') {
     const versions = args.slice(1);
@@ -126,18 +138,7 @@ if (mode === '--download-electron') {
     }
     const electronMajor = parseInt(electronVersion.split('.')[0], 10);
 
-    // Electron major -> ABI mapping
-    const electronAbiMap = {
-        32: '128',
-        33: '130',
-        34: '132',
-        35: '133',
-        36: '135',
-        37: '136',
-        38: '139',
-        39: '140',
-    };
-    const targetAbi = electronAbiMap[electronMajor];
+    const targetAbi = ELECTRON_ABI_MAP[electronMajor];
     if (!targetAbi) {
         console.error(`Unknown Electron major version: ${electronMajor}`);
         process.exit(1);
@@ -171,6 +172,14 @@ if (mode === '--download-electron') {
     fs.copyFileSync(SOURCE, dest);
     console.log(`Collected: ${dest}`);
 
+    // Clean up nested node_modules from prebuild-install before ABI verification
+    // so the cleanup always runs regardless of whether verification succeeds or fails.
+    const nestedModules = path.join(ROOT, 'node_modules', 'better-sqlite3', 'node_modules');
+    if (fs.existsSync(nestedModules)) {
+        fs.rmSync(nestedModules, { recursive: true, force: true });
+        console.log('Cleaned up nested node_modules from prebuild-install.');
+    }
+
     // Verify ABI
     const { spawnSync } = require('child_process');
     const result = spawnSync(process.execPath, ['-e', `require(${JSON.stringify(dest)})`], {
@@ -192,13 +201,6 @@ if (mode === '--download-electron') {
             `ABI mismatch! Binary loaded under Node.js ${process.version} — expected Electron ABI ${targetAbi}.`,
         );
         process.exit(1);
-    }
-
-    // Clean up nested node_modules from prebuild-install
-    const nestedModules = path.join(ROOT, 'node_modules', 'better-sqlite3', 'node_modules');
-    if (fs.existsSync(nestedModules)) {
-        fs.rmSync(nestedModules, { recursive: true, force: true });
-        console.log('Cleaned up nested node_modules from prebuild-install.');
     }
 
     process.exit(0);
@@ -228,18 +230,7 @@ if (mode === '--node') {
     const electronVersion = electronVersionMatch[1];
     const electronMajor = parseInt(electronVersion.split('.')[0], 10);
 
-    // Electron major -> ABI mapping (update when targeting new Electron versions)
-    const electronAbiMap = {
-        32: '128',
-        33: '130',
-        34: '132',
-        35: '133',
-        36: '135',
-        37: '136',
-        38: '139',
-        39: '140',
-    };
-    targetAbi = electronAbiMap[electronMajor];
+    targetAbi = ELECTRON_ABI_MAP[electronMajor];
     if (!targetAbi) {
         console.error(`Unknown Electron major version: ${electronMajor}`);
         process.exit(1);


### PR DESCRIPTION
## Problem

make failed on Windows because the Makefile used Unix-only shell commands (m -rf, mkdir -p, ls) and lectron-rebuild --build-from-source which requires Visual Studio Build Tools.

## Changes

- **package.json**: Align ngines.vscode with installed @types/vscode ^1.118.0 to fix vsce packaging error
- **Makefile**: Replace m -rf, mkdir -p, and ls with cross-platform 
ode -e equivalents; replace lectron-rebuild with prebuild-install --runtime electron (downloads prebuilt binary from GitHub releases, no C++ compiler needed)
- **scripts/collect-prebuilds.js**: Add --download-electron <version> mode that downloads the Electron prebuild via prebuild-install and verifies the binary ABI matches the expected value before accepting it