### PR TITLE
fix: allow building and running

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,9 +268,9 @@
     "scripts": {
         "vscode:prepublish": "npm run compile",
         "rebuild": "electron-rebuild -v 39.3.0",
-        "rebuild:node": "cd node_modules/better-sqlite3 && node-gyp rebuild --release",
-        "collect:node": "node scripts/collect-prebuilds.js --node",
-        "collect:electron": "node scripts/collect-prebuilds.js --electron",
+        "rebuild:node": "cd node_modules/better-sqlite3 && npm_config_runtime=node npm_config_target=24.15.0 npm_config_disturl=https://nodejs.org/download/release node-gyp rebuild --release",
+		"collect:node": "npm_config_target=24.15.0 node scripts/collect-prebuilds.js --node",
+		"collect:electron": "node scripts/collect-prebuilds.js --electron",
         "prebuilds": "npm run rebuild:node && npm run collect:node && npm run rebuild && npm run collect:electron",
         "compile": "webpack --mode production && npm run copy-fixtures",
         "compile:tests": "tsc -p tsconfig.test.json",

--- a/scripts/collect-prebuilds.js
+++ b/scripts/collect-prebuilds.js
@@ -211,13 +211,28 @@ if (!fs.existsSync(SOURCE)) {
     console.error(`Source not found: ${SOURCE}`);
     process.exit(1);
 }
+const NODE_ABI_MAP = { 18: '108', 20: '115', 22: '127', 23: '131', 24: '137' };
 
 const abi = process.versions.modules;
 
 let targetAbi;
 if (mode === '--node') {
-    targetAbi = abi;
-    console.log(`Collecting Node.js prebuild (ABI ${targetAbi})`);
+    // When cross-compiling via npm_config_target (e.g. target Node 24 from Node 22 host),
+    // process.versions.modules is the host ABI and would label the output incorrectly.
+    const targetVersion = process.env.npm_config_target || abi;
+    if (targetVersion) {
+        const targetMajor = parseInt(String(targetVersion).split('.')[0], 10);
+        const mappedAbi = NODE_ABI_MAP[targetMajor];
+        if (!mappedAbi) {
+            console.error(`Unknown Node major version in npm_config_target: ${targetMajor}`);
+            process.exit(1);
+        }
+        targetAbi = mappedAbi;
+        console.log(`Collecting Node.js prebuild for target ${targetVersion} (ABI ${targetAbi})`);
+    } else {
+        targetAbi = abi;
+        console.log(`Collecting Node.js prebuild (ABI ${targetAbi})`);
+    }
 } else {
     // Read the Electron version from package.json rebuild script
     const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));


### PR DESCRIPTION
# Summary
This PR fixes the extension startup failure caused by a native module ABI mismatch after installation. The packaged better-sqlite3 binary was built/labeled for ABI 140, while the VS Code remote extension host requires ABI 137.

# Problem
Users saw this runtime error when opening SQLite databases:
Failed to open SQLite databases... compiled against a different Node.js version (NODE_MODULE_VERSION 140 vs required 137).

# What changed

- Updated packaging scripts to rebuild Node-targeted native binaries for Node 24.15.0 (ABI 137).
- Fixed Node prebuild collection so ABI naming follows the target runtime (npm_config_target), not the host Node ABI.
- Restored Electron rebuild target to a version that compiles successfully with the current better-sqlite3 release in this repo.
- Kept Electron prebuild collection intact while ensuring Node 24 maps to ABI 137.

# Result
The package pipeline now produces:

- Node prebuild for ABI 137 (used by VS Code remote extension host).
- Electron prebuild for ABI 140 (for Electron-target scenarios).
- 
# Validation

- Ran npm run prebuilds successfully.
- Verified output includes Node target 24.15.0 collected as ABI 137.
- Ran npm run package successfully and generated a working VSIX artifact.

# Risk/impact
Low risk. Changes are limited to build and prebuild collection scripts; runtime feature behavior is unchanged.